### PR TITLE
fix(ci): replace duplicate dependabot entry with PR title rewriting workflow

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -21,9 +21,13 @@ This directory contains GitHub Actions workflows and Dependabot configuration fo
 ## Dependabot (`dependabot.yml`)
 
 - Targets `github-actions` ecosystem only
-- Uses **two separate update entries** to produce different conventional commit prefixes based on update type:
-  - Minor/patch updates use `fix(deps):` prefix → triggers patch version bump
-  - Major updates use `feat!:(deps):` prefix → triggers major version bump
-- This workaround exists because Dependabot does not natively support different prefixes per semver bump type
-- The major entry uses `"feat!:"` (with colon included) because Dependabot only auto-appends a colon when the prefix ends with a letter, number, `)`, or `]`
-- Auto-rebasing is enabled on both entries
+- Single update entry with `fix(deps):` conventional commit prefix for all updates
+- Auto-rebasing is enabled
+
+### Major version PR title rewriting (`workflows/dependabot-major-prefix.yml`)
+
+- Dependabot cannot natively assign different commit prefixes per semver update type
+- A `pull_request_target` workflow detects major-version Dependabot PRs using `dependabot/fetch-metadata`
+- Rewrites PR title from `fix(deps): ...` to `feat!(deps): ...` so squash-merge commits trigger major version bumps via git-cliff
+- Uses `pull_request_target` (not `pull_request`) because Dependabot PRs have read-only tokens under the `pull_request` event
+- Safe because the workflow never checks out PR code — only reads event metadata and edits the PR title

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 
 updates:
-  # Minor and patch updates — treated as patch-level bumps
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -10,21 +9,3 @@ updates:
     commit-message:
       prefix: "fix"
       include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # Major updates — treated as breaking changes
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "auto"
-    commit-message:
-      prefix: "feat!:"
-      include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"

--- a/.github/workflows/dependabot-major-prefix.yml
+++ b/.github/workflows/dependabot-major-prefix.yml
@@ -1,0 +1,30 @@
+name: Dependabot Major Version Prefix
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  rewrite-title:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rewrite title for major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_TITLE="${PR_TITLE/fix\(deps\)/feat!\(deps\)}"
+          gh pr edit "$PR_NUMBER" --title "$NEW_TITLE" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Consolidate two dependabot.yml entries (which violated the uniqueness
constraint) into a single entry with a `fix` prefix. Add a
pull_request_target workflow that uses dependabot/fetch-metadata to
detect major version updates and rewrites the PR title from
`fix(deps):` to `feat!(deps):` so squash-merge commits still trigger
the correct git-cliff version bumps.