### PR TITLE
fix(ci): run git-cliff directly to avoid action jq stdout bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         id: check
         run: |
           CURRENT="${{ steps.current_tag.outputs.tag }}"
-          NEXT="$(echo "${{ steps.next_version.outputs.stdout }}" | xargs)"
+          NEXT="$(git-cliff --bumped-version 2>/dev/null | tail -1 | xargs)"
 
           if [ -z "$NEXT" ] || [ "$NEXT" = "$CURRENT" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- `orhun/git-cliff-action@v4` has a bug where its `run.sh` uses `jq` without the `-R` flag to encode output into a GitHub Actions output variable
- `v1.0.0` is not valid JSON, so jq fails with `Invalid numeric literal at line 2, column 0`, leaving `outputs.stdout` empty
- The check step saw `NEXT=""` → `skip=true` → no release was created

## Fix

Run `git-cliff --bumped-version` directly in the check step instead of relying on `steps.next_version.outputs.stdout`. The binary is in PATH after `orhun/git-cliff-action` installs it in the previous step. `tail -1` strips any warning lines from output.

## Test plan

- [ ] Verify the release workflow runs successfully on merge to main
- [ ] Confirm a `v1.0.0` release is created from accumulated fix commits