### PR TITLE
fix(ci): scope tag pattern to semver and update alias tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current tag
         id: current_tag
         run: |
-          TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo '')"
+          TAG="$(git tag --list 'v*.*.*' --sort=-version:refname | head -1)"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Determine next version
@@ -64,3 +64,13 @@ jobs:
             --title "${{ steps.check.outputs.version }}" \
             --notes "${{ steps.changelog.outputs.content }}" \
             --target "${{ github.sha }}"
+
+      - name: Update alias tags
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          VERSION="${{ steps.check.outputs.version }}"
+          MAJOR="v$(echo "${VERSION#v}" | cut -d. -f1)"
+          MINOR="v$(echo "${VERSION#v}" | cut -d. -f1-2)"
+          git tag -f "$MAJOR" "${{ github.sha }}"
+          git tag -f "$MINOR" "${{ github.sha }}"
+          git push origin "$MAJOR" "$MINOR" --force

--- a/cliff.toml
+++ b/cliff.toml
@@ -32,4 +32,4 @@ commit_parsers = [
     { message = "^ci", skip = true },
     { message = "^build", skip = true },
 ]
-tag_pattern = "v[0-9].*"
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"


### PR DESCRIPTION
## Summary

- Updates `tag_pattern` in `cliff.toml` from `v[0-9].*` to `v[0-9]+\.[0-9]+\.[0-9]+` so git-cliff ignores major/minor alias tags (`v1`, `v3.0`, etc.) and only tracks full semver releases
- Fixes `Get current tag` step to use `git tag --list 'v*.*.*'` instead of `git describe --tags` so alias tags don't interfere with current version detection
- Adds `Update alias tags` step that force-updates major (`v1`) and minor (`v1.3`) alias tags after each release

## Test plan

- [ ] Verify release workflow runs without semver parse errors on merge to main
- [ ] Confirm a `v3.0.1` release is created from commits since `v3.0.0`
- [ ] Confirm `v3` and `v3.0` alias tags are updated to point at the released commit