### PR TITLE
feat!(ci): add git-cliff to PATH and require squash merge for releases

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -31,3 +31,5 @@ This directory contains GitHub Actions workflows and Dependabot configuration fo
 - Rewrites PR title from `fix(deps): ...` to `feat!(deps): ...` so squash-merge commits trigger major version bumps via git-cliff
 - Uses `pull_request_target` (not `pull_request`) because Dependabot PRs have read-only tokens under the `pull_request` event
 - Safe because the workflow never checks out PR code — only reads event metadata and edits the PR title
+
+**REQUIRED: All PRs must be merged via squash merge.** The title-rewriting only affects the PR title — the rewritten title becomes the commit message only when squash merging. A regular merge commit preserves the original commit message, causing git-cliff to see `fix(deps):` instead of `feat!(deps):` and produce the wrong version bump.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Check if release is needed
         id: check
         run: |
+          export PATH="$RUNNER_TEMP/git-cliff/bin:$PATH"
           CURRENT="${{ steps.current_tag.outputs.tag }}"
           NEXT="$(git-cliff --bumped-version 2>/dev/null | tail -1 | xargs)"
 


### PR DESCRIPTION
## Summary

- Adds `$RUNNER_TEMP/git-cliff/bin` to PATH in the `Check if release is needed` step — `orhun/git-cliff-action` installs the binary there but does not add it to `$GITHUB_PATH`, so `git-cliff` was not resolvable in subsequent steps, silently producing an empty version and skipping every release
- Documents that **all PRs must be squash merged** for the `dependabot-major-prefix.yml` title-rewriting to take effect — with a regular merge commit, the rewritten PR title is never used as the commit message and git-cliff sees the wrong commit type

## Note on version bump

This PR is intentionally titled `feat!` to produce a `v4.0.0` release on merge, accounting for the two major dependency bumps (`actions/checkout` 4→6, `actions/setup-node` 4→6) that landed with incorrect `fix(deps):` commit messages before squash merge was enforced.

## Test plan

- [ ] Verify release workflow runs and produces `v4.0.0` on merge
- [ ] Confirm `v4` and `v4.0` alias tags are created and point at the merge commit