### PR TITLE
feat(ci)!: correct breaking change syntax in major version rewrite workflow

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -15,7 +15,7 @@ This directory contains GitHub Actions workflows and Dependabot configuration fo
 **Semver mapping** (handled by git-cliff via conventional commits):
 - `feat` → minor bump
 - `fix` → patch bump
-- `!` suffix or `BREAKING CHANGE` footer → major bump
+- `!` after type/scope (e.g. `feat(ci)!:`) or `BREAKING CHANGE` footer → major bump
 - `chore`, `ci`, `docs`, `style` → no bump
 
 ## Dependabot (`dependabot.yml`)
@@ -28,8 +28,8 @@ This directory contains GitHub Actions workflows and Dependabot configuration fo
 
 - Dependabot cannot natively assign different commit prefixes per semver update type
 - A `pull_request_target` workflow detects major-version Dependabot PRs using `dependabot/fetch-metadata`
-- Rewrites PR title from `fix(deps): ...` to `feat!(deps): ...` so squash-merge commits trigger major version bumps via git-cliff
+- Rewrites PR title from `fix(deps): ...` to `feat(deps)!: ...` so squash-merge commits trigger major version bumps via git-cliff
 - Uses `pull_request_target` (not `pull_request`) because Dependabot PRs have read-only tokens under the `pull_request` event
 - Safe because the workflow never checks out PR code — only reads event metadata and edits the PR title
 
-**REQUIRED: All PRs must be merged via squash merge.** The title-rewriting only affects the PR title — the rewritten title becomes the commit message only when squash merging. A regular merge commit preserves the original commit message, causing git-cliff to see `fix(deps):` instead of `feat!(deps):` and produce the wrong version bump.
+**REQUIRED: All PRs must be merged via squash merge.** The title-rewriting only affects the PR title — the rewritten title becomes the commit message only when squash merging. A regular merge commit preserves the original commit message, causing git-cliff to see `fix(deps):` instead of `feat(deps)!:` and produce the wrong version bump.

--- a/.github/workflows/dependabot-major-prefix.yml
+++ b/.github/workflows/dependabot-major-prefix.yml
@@ -26,5 +26,5 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          NEW_TITLE="${PR_TITLE/fix\(deps\)/feat!\(deps\)}"
+          NEW_TITLE="${PR_TITLE/fix\(deps\)/feat\(deps\)!}"
           gh pr edit "$PR_NUMBER" --title "$NEW_TITLE" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary

- Fixes `dependabot-major-prefix.yml` to produce `feat(deps)!:` instead of `feat!(deps):` — the `!` must come after the type/scope per the conventional commits spec, not between type and scope
- Updates `CLAUDE.md` to reflect the correct syntax and clarify the breaking change format

## Why this matters

`feat!(deps):` is not parsed as a breaking change by git-cliff — the `!` in `feat!(scope):` position is not recognized. Only `feat(scope)!:` (or `feat!:` without a scope) triggers a major version bump.

## Verification

This PR is intentionally titled `feat(ci)!:` to verify that the release workflow correctly produces a `v4.0.0` major release on merge.

## Test plan

- [ ] Confirm release workflow produces `v4.0.0` on merge
- [ ] Confirm `v4` and `v4.0` alias tags are created